### PR TITLE
Fix broken menu links

### DIFF
--- a/_data/menus.yml
+++ b/_data/menus.yml
@@ -5,9 +5,9 @@
 - title: Submit
   items:
   - title: Call for Papers
-    url  : 'https://owasp.submittable.com/submit/157930/global-appsec-dublin-2020-cfp'
+    url  : program/call-for-papers
   - title: Call for Trainings
-    url  : 'https://owasp.submittable.com/submit/157929/global-appsec-dublin-2020-cft'
+    url  : program/call-for-trainings
 - title: Sponsor
   items: 
   - title: Opportunities


### PR DESCRIPTION
Currently, when clicking on `Submit > Call for Papers` from the dropdown menu on the site, it throws a `404`. This is because it redirects you to `https://dublin.globalappsec.org/https://owasp.submittable.com/submit/157930/global-appsec-dublin-2020-cfp`.

![image](https://user-images.githubusercontent.com/6052785/73174789-9000d300-4100-11ea-95b2-b02b7047ae6d.png)

It seems that the way this site is setup, it does not support absolute URLs in the nav menu.
We can bypass this and implement a hotfix by redirecting to `programm/call-for-papers` locally, which already has the correct link on it.

Same applies for Call for Trainings.
